### PR TITLE
Pump cosmos-sdk version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -229,7 +229,7 @@ replace (
 	github.com/99designs/keyring => github.com/cosmos/keyring v1.2.0
 
 	github.com/coinbase/rosetta-sdk-go => github.com/coinbase/mesh-sdk-go v0.7.9
-	github.com/cosmos/cosmos-sdk => github.com/hyle-team/cosmos-sdk v0.46.31-0.20250411124134-7e87d2103e03
+	github.com/cosmos/cosmos-sdk => github.com/hyle-team/cosmos-sdk v0.46.32
 	github.com/cosmos/ibc-go/v6 => github.com/hyle-team/ibc-go/v6 v6.0.0-20241031152903-f38c2bf016e9
 
 	// use Evmos geth fork

--- a/go.sum
+++ b/go.sum
@@ -780,6 +780,7 @@ github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixH
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/hyle-team/cosmos-sdk v0.46.31-0.20250411124134-7e87d2103e03 h1:qBQjVQdFmIH8ZbCvZa8NhaOh3nzuYHXIBBE+hNC8tsA=
 github.com/hyle-team/cosmos-sdk v0.46.31-0.20250411124134-7e87d2103e03/go.mod h1:exJNK+hAaBpOdCPfS60Y9UvSy/iepf0pzd9XLeUDaso=
+github.com/hyle-team/cosmos-sdk v0.46.32/go.mod h1:exJNK+hAaBpOdCPfS60Y9UvSy/iepf0pzd9XLeUDaso=
 github.com/hyle-team/ibc-go/v6 v6.0.0-20241031152903-f38c2bf016e9 h1:TjQXfa93o5NdDOolRfAI58ABI08Jvavp/TqSpIyeFaY=
 github.com/hyle-team/ibc-go/v6 v6.0.0-20241031152903-f38c2bf016e9/go.mod h1:/1tIKulumMapoo5kkxOP7/Zw2zUGYVMsvd2anyiaB6I=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,7 @@ github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmK
 github.com/huin/goupnp v1.0.3 h1:N8No57ls+MnjlB+JPiCVSOyy/ot7MJTqlo7rn+NYSqQ=
 github.com/huin/goupnp v1.0.3/go.mod h1:ZxNlw5WqJj6wSsRK5+YfflQGXYfccj5VgQsMNixHM7Y=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
-github.com/hyle-team/cosmos-sdk v0.46.31-0.20250411124134-7e87d2103e03 h1:qBQjVQdFmIH8ZbCvZa8NhaOh3nzuYHXIBBE+hNC8tsA=
-github.com/hyle-team/cosmos-sdk v0.46.31-0.20250411124134-7e87d2103e03/go.mod h1:exJNK+hAaBpOdCPfS60Y9UvSy/iepf0pzd9XLeUDaso=
+github.com/hyle-team/cosmos-sdk v0.46.32 h1:eN1YkNUVtAQ23285Z377fuIlX0Y3C/Anyli8RdLjJpI=
 github.com/hyle-team/cosmos-sdk v0.46.32/go.mod h1:exJNK+hAaBpOdCPfS60Y9UvSy/iepf0pzd9XLeUDaso=
 github.com/hyle-team/ibc-go/v6 v6.0.0-20241031152903-f38c2bf016e9 h1:TjQXfa93o5NdDOolRfAI58ABI08Jvavp/TqSpIyeFaY=
 github.com/hyle-team/ibc-go/v6 v6.0.0-20241031152903-f38c2bf016e9/go.mod h1:/1tIKulumMapoo5kkxOP7/Zw2zUGYVMsvd2anyiaB6I=


### PR DESCRIPTION
Pumped cosmos-sdk version to v0.46.32 with improved genesis params validation.