### PR TITLE
Reject transactions without commission

### DIFF
--- a/app/ante/evm/eth.go
+++ b/app/ante/evm/eth.go
@@ -260,10 +260,6 @@ func (egcd EthGasConsumeDecorator) AnteHandle(ctx sdk.Context, tx sdk.Tx, simula
 // deductFee checks if the fee payer has enough funds to pay for the fees and deducts them.
 // If the spendable balance is not enough, it tries to claim enough staking rewards to cover the fees.
 func (egcd EthGasConsumeDecorator) deductFee(ctx sdk.Context, fees sdk.Coins, feePayer sdk.AccAddress) error {
-	if fees.IsZero() {
-		return nil
-	}
-
 	// If the account balance is not sufficient, try to withdraw enough staking rewards
 	if err := anteutils.ClaimStakingRewardsIfNecessary(ctx, egcd.bankKeeper, egcd.distributionKeeper, egcd.stakingKeeper, feePayer, fees); err != nil {
 		return err


### PR DESCRIPTION
Remove the ability to send feeless transactions over the EVM module. To avoid the error `failed to deduct commission: incorrect commission denomination; received: ; required: abridge: insufficient commission: insufficient commission`, it is necessary to set `no_base_fee: false` on feemarket module  